### PR TITLE
feat: add tsconfig.json

### DIFF
--- a/embark-javascript-package/{{cookiecutter.repo_name}}/tsconfig.json
+++ b/embark-javascript-package/{{cookiecutter.repo_name}}/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
Adds a `tsconfig.json` file in the root so that typecheck checks only local package and not the entire dependency tree.